### PR TITLE
ci(release): use `changeset publish` instead of `pnpm publish`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
           title: 'chore: version package'
           commit: 'chore: version package'
           version: node .github/changeset-version.cjs
-          publish: pnpm publish --access public --provenance --no-git-checks
+          publish: pnpm exec changeset publish
           createGithubReleases: true
 
         env:

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   },
   "publishConfig": {
     "access": "public",
-    "registry": "https://registry.npmjs.org/"
+    "registry": "https://registry.npmjs.org/",
+    "provenance": true
   },
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## 🎯 Changes

- use `changeset publish` instead of `pnpm publish` in the release workflow to ensure 
github releases and tags are created automatically

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/saud-alnasser/cachescribe/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added or updated the tests related to the changes made.
- [x] If necessary, I have added documentation related to the changes made.
