### PR TITLE
refactor: replace zod schema deprecated function `nonempty()` with `min(1)`

### DIFF
--- a/.changeset/tricky-eyes-beam.md
+++ b/.changeset/tricky-eyes-beam.md
@@ -1,0 +1,5 @@
+---
+"cachescribe": patch
+---
+
+resolved usage of zod deprecated functions. 

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,9 +1,9 @@
-import superjson from 'superjson';
-import slash from 'slash';
 import fs from 'fs-extra';
-import { hash, hashAlgorithms } from './hash';
 import { join } from 'node:path';
+import slash from 'slash';
+import superjson from 'superjson';
 import { z } from 'zod';
+import { hash, hashAlgorithms } from './hash';
 
 const CacheOptionsSchema = z.object({
   /**
@@ -14,14 +14,14 @@ const CacheOptionsSchema = z.object({
    * @default
    * 'default'
    */
-  namespace: z.string().nonempty().optional(),
+  namespace: z.string().min(1).optional(),
 
   /**
    * directory that the snapshot file will be written in.
    *
    * @default node_modules/.cache/cachescribe
    */
-  directory: z.string().nonempty().optional(),
+  directory: z.string().min(1).optional(),
 
   /**
    * file extension to be used for the cache snapshot file.
@@ -98,7 +98,7 @@ const CacheEntrySchema = z.object({
     /**
      * key of the entry.
      */
-    key: z.string().nonempty(),
+    key: z.string().min(1),
 
     /**
      * duration in seconds for the time to live for the entry.
@@ -129,7 +129,7 @@ const CacheSnapshotSchema = z.object({
     /**
      * id of the snapshot file.
      */
-    id: z.string().nonempty(),
+    id: z.string().min(1),
   }),
 
   /**
@@ -145,7 +145,10 @@ const CacheEntryParamsSchema = z
     entries: z
       .array(
         z
-          .object({ key: z.string().nonempty(), value: z.unknown() })
+          .object({
+            key: z.string().min(1),
+            value: z.unknown(),
+          })
           .merge(CacheOptionsSchema.pick({ ttl: true }))
       )
       .nonempty()

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
-export * from './hash';
 export * from './cache';
+export * from './hash';


### PR DESCRIPTION
## 🎯 Changes

- replaced zod `nonempty()` function with `min(1)`

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/saud-alnasser/cachescribe/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added or updated the tests related to the changes made.
- [x] If necessary, I have added documentation related to the changes made.
